### PR TITLE
Add tip to install fonts-powerline when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ And source it in your `.bashrc`
 
     source ~/.fancy-prompt.sh
 
+If the triangles aren't displayed correctly, try `sudo apt install fonts-powerline`.
 
 # Note:
 * This assumes you have git installed.


### PR DESCRIPTION
In the default terminal of Ubuntu 21.04, the triangles were displayed incorrectly. The tip was in [this answer](https://askubuntu.com/a/1171263/986839).