### PR TITLE
Fix for git clone [--separate-git-dir <git dir>]

### DIFF
--- a/fancy-prompt.sh
+++ b/fancy-prompt.sh
@@ -64,7 +64,7 @@ __powerline() {
 
     __git_info() {
         # no .git directory
-    	[ -d .git ] || return
+    	[ -e .git ] || return
 
         local aheadN
         local behindN


### PR DESCRIPTION
Hi @pjmp,

When cloning or initing git repository, it is possible to place git directory elsewhere with parameter "--separate-git-dir". In such case instead of git directory ".git" file is created (it contains path to real git directory). I use it a lot.

This commit changes test for ".git" from directory-specific to general.

/Maciej